### PR TITLE
Updated to work with Generic.Rep v6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+/bower_components/
+/node_modules/
+/.pulp-cache/
+/output/
+/generated-docs/
+/.psc-package/
+/.psc*
+/.purs*
+/.psa*

--- a/bower.json
+++ b/bower.json
@@ -12,15 +12,16 @@
     "output"
   ],
   "dependencies": {
-    "purescript-prelude": "^3.1.0",
-    "purescript-console": "^3.0.0",
-    "purescript-generics-rep": "^5.3.0",
-    "purescript-argonaut": "^3.1.0",
-    "purescript-argonaut-codecs": "^3.2.0",
-    "purescript-argonaut-generic": "^1.2.0"
+    "purescript-prelude": "^4.1.0",
+    "purescript-console": "^4.2.0",
+    "purescript-generics-rep": "^6.1.0",
+    "purescript-argonaut": "^5.0.0",
+    "purescript-argonaut-codecs": "^5.1.0",
+    "purescript-argonaut-generic": "^3.0.0",
+    "purescript-foreign-object": "^1.1.0"
   },
   "devDependencies": {
-    "purescript-psci-support": "^3.0.0",
-    "purescript-test-unit": "^13.0.0"
+    "purescript-psci-support": "^4.0.0",
+    "purescript-test-unit": "^14.0.0"
   }
 }

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,0 +1,121 @@
+{-
+Welcome to your new Dhall package-set!
+
+Below are instructions for how to edit this file for most use
+cases, so that you don't need to know Dhall to use it.
+
+## Warning: Don't Move This Top-Level Comment!
+
+Due to how `dhall format` currently works, this comment's
+instructions cannot appear near corresponding sections below
+because `dhall format` will delete the comment. However,
+it will not delete a top-level comment like this one.
+
+## Use Cases
+
+Most will want to do one or both of these options:
+1. Override/Patch a package's dependency
+2. Add a package not already in the default package set
+
+This file will continue to work whether you use one or both options.
+Instructions for each option are explained below.
+
+### Overriding/Patching a package
+
+Purpose:
+- Change a package's dependency to a newer/older release than the
+    default package set's release
+- Use your own modified version of some dependency that may
+    include new API, changed API, removed API by
+    using your custom git repo of the library rather than
+    the package set's repo
+
+Syntax:
+Replace the overrides' "{=}" (an empty record) with the following idea
+The "//" or "⫽" means "merge these two records and
+  when they have the same value, use the one on the right:"
+-------------------------------
+let override =
+  { packageName =
+      upstream.packageName // { updateEntity1 = "new value", updateEntity2 = "new value" }
+  , packageName =
+      upstream.packageName // { version = "v4.0.0" }
+  , packageName =
+      upstream.packageName // { repo = "https://www.example.com/path/to/new/repo.git" }
+  }
+-------------------------------
+
+Example:
+-------------------------------
+let overrides =
+  { halogen =
+      upstream.halogen // { version = "master" }
+  , halogen-vdom =
+      upstream.halogen-vdom // { version = "v4.0.0" }
+  }
+-------------------------------
+
+### Additions
+
+Purpose:
+- Add packages that aren't already included in the default package set
+
+Syntax:
+Replace the additions' "{=}" (an empty record) with the following idea:
+-------------------------------
+let additions =
+  { "package-name" =
+       mkPackage
+         [ "dependency1"
+         , "dependency2"
+         ]
+         "https://example.com/path/to/git/repo.git"
+         "tag ('v4.0.0') or branch ('master')"
+  , "package-name" =
+       mkPackage
+         [ "dependency1"
+         , "dependency2"
+         ]
+         "https://example.com/path/to/git/repo.git"
+         "tag ('v4.0.0') or branch ('master')"
+  , etc.
+  }
+-------------------------------
+
+Example:
+-------------------------------
+let additions =
+  { benchotron =
+      mkPackage
+        [ "arrays"
+        , "exists"
+        , "profunctor"
+        , "strings"
+        , "quickcheck"
+        , "lcg"
+        , "transformers"
+        , "foldable-traversable"
+        , "exceptions"
+        , "node-fs"
+        , "node-buffer"
+        , "node-readline"
+        , "datetime"
+        , "now"
+        ]
+        "https://github.com/hdgarrood/purescript-benchotron.git"
+        "v7.0.0"
+  }
+-------------------------------
+-}
+
+let mkPackage =
+      https://raw.githubusercontent.com/purescript/package-sets/psc-0.13.0-20190614/src/mkPackage.dhall sha256:0b197efa1d397ace6eb46b243ff2d73a3da5638d8d0ac8473e8e4a8fc528cf57
+
+let upstream =
+      https://raw.githubusercontent.com/purescript/package-sets/psc-0.13.0-20190614/src/packages.dhall sha256:5cbf2418298e7de762401c5719c6eb18eda4c67ba512b3f076b50a793a7fc482
+
+let overrides = {=}
+
+let additions = {=}
+
+in  upstream // overrides // additions

--- a/spago.dhall
+++ b/spago.dhall
@@ -1,0 +1,19 @@
+{-
+Welcome to a Spago project!
+You can edit this file as you like.
+-}
+{ name =
+    "argonaut-aeson-generic"
+, dependencies =
+    [ "argonaut"
+    , "argonaut-codecs"
+    , "argonaut-generic"
+    , "console"
+    , "effect"
+    , "foreign-object"
+    , "psci-support"
+    , "test-unit"
+    ]
+, packages =
+    ./packages.dhall
+}

--- a/src/Data/Argonaut/Aeson/Decode/Generic.purs
+++ b/src/Data/Argonaut/Aeson/Decode/Generic.purs
@@ -8,14 +8,14 @@ import Prelude
 
 import Control.Alt ((<|>))
 import Data.Argonaut.Aeson.Options (Options(Options), SumEncoding(..))
-import Data.Argonaut.Core (Json, foldJson, fromBoolean, fromNull, fromNumber, fromObject, fromString, toObject, toString)
+import Data.Argonaut.Core (Json, caseJson, fromBoolean, fromNumber, fromObject, fromString, jsonNull, toObject, toString)
 import Data.Argonaut.Decode.Generic.Rep (class DecodeRepArgs, decodeRepArgs)
 import Data.Array (singleton)
 import Data.Bifunctor (lmap)
 import Data.Either (Either(..), note)
 import Data.Generic.Rep as Rep
 import Data.Maybe (Maybe(..))
-import Data.StrMap as SM
+import Foreign.Object as SM
 import Data.Symbol (class IsSymbol, SProxy(..), reflectSymbol)
 
 class DecodeAeson r where
@@ -28,12 +28,12 @@ instance decodeAesonSum :: (DecodeAeson a, DecodeAeson b) => DecodeAeson (Rep.Su
   decodeAeson o j = Rep.Inl <$> decodeAeson o j <|> Rep.Inr <$> decodeAeson o j
 
 toJsonArray :: Json -> Array Json
-toJsonArray = foldJson
-  (singleton <<< fromNull)
+toJsonArray = caseJson
+  (const $ singleton jsonNull)
   (singleton <<< fromBoolean)
   (singleton <<< fromNumber)
   (singleton <<< fromString)
-  id
+  (\x -> x)
   (singleton <<< fromObject)
 
 instance decodeAesonConstructor :: (IsSymbol name, DecodeRepArgs a) => DecodeAeson (Rep.Constructor name a) where

--- a/src/Data/Argonaut/Aeson/Encode/Generic.purs
+++ b/src/Data/Argonaut/Aeson/Encode/Generic.purs
@@ -15,15 +15,15 @@ import Record (get)
 import Data.Argonaut.Aeson.Options (Options(Options), SumEncoding(..))
 import Data.Argonaut.Core (Json, fromArray, fromObject, fromString)
 import Data.Argonaut.Encode.Class (class EncodeJson, encodeJson)
---import Data.Argonaut.Encode.Generic.Rep (class EncodeRepFields, encodeRepFields)
 import Data.Array (cons, head, length, snoc)
 import Data.Generic.Rep as Rep
 import Data.Maybe (fromJust)
 import Data.Symbol (class IsSymbol, SProxy(..), reflectSymbol)
 import Foreign.Object as FO
 import Partial.Unsafe (unsafePartial)
-import Type.Row (class Cons, class RowToList, Cons, Nil, RLProxy(..), kind RowList)
-
+import Type.Row (class Cons)
+import Type.RowList (class RowToList, Nil, Cons, RLProxy(..), kind RowList)
+    
 class EncodeAeson r where
   encodeAeson :: Options -> r -> Json
 


### PR DESCRIPTION
Records no longer have a Generic representation, so we need to use row
types to walk through the fields.

Have also updated the other libraries. The tests pass, it all seems to work and I
have data going back and forth between a Servant server and the Purescript client correctly.