### PR TITLE
Update the repository url in the bower.json file to the one known by the registry

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "license": "MPL-2.0",
   "repository": {
     "type": "git",
-    "url": "git://github.com/coot/purescript-argonaut-aeson-generic"
+    "url": "https://github.com/coot/purescript-argonaut-aeson-generic.git"
   },
   "ignore": [
     "**/.*",


### PR DESCRIPTION
This package is registered with repository https://github.com/coot/purescript-argonaut-aeson-generic.git in the registry, so Pulp refuses to publish it:

```
> npx pulp publish --no-push
Checking your package is registered in purescript/registry...
* A package with the name purescript-argonaut-aeson-generic already exists in the registry, but the repository urls did not match.
* Repository url in your bower.json file:
*   git://github.com/coot/purescript-argonaut-aeson-generic
* Repository url in the registry:
*   https://github.com/coot/purescript-argonaut-aeson-generic.git
* Please make sure these urls match.
* ERROR: Package repository url mismatch
```

Unfortunately you’ll need to tag a v0.2.1 but then Pulp should be able to upload the package.