### PR TITLE
update Spago config; provide Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+# source: https://github.com/purescript-contrib/purescript-argonaut-generic/blob/main/.github/workflows/ci.yml
+name: CI
+
+on:
+  push:
+    branches: '*'
+  pull_request:
+    branches: '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up a PureScript toolchain
+        uses: purescript-contrib/setup-purescript@main
+        with:
+          purescript: "0.13.8"
+
+      - name: Cache PureScript dependencies
+        uses: actions/cache@v2
+        with:
+          key: ${{ runner.os }}-spago-${{ hashFiles('**/*.dhall') }}
+          path: |
+            .spago
+            output
+      - name: Install dependencies
+        run: spago install
+
+      - name: Build source
+        run: spago build --no-install --purs-args '--censor-lib --strict'
+
+      - name: Run tests
+        run: spago test --no-install

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /.psc*
 /.purs*
 /.psa*
+/.spago

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,121 +1,21 @@
-{-
-Welcome to your new Dhall package-set!
-
-Below are instructions for how to edit this file for most use
-cases, so that you don't need to know Dhall to use it.
-
-## Warning: Don't Move This Top-Level Comment!
-
-Due to how `dhall format` currently works, this comment's
-instructions cannot appear near corresponding sections below
-because `dhall format` will delete the comment. However,
-it will not delete a top-level comment like this one.
-
-## Use Cases
-
-Most will want to do one or both of these options:
-1. Override/Patch a package's dependency
-2. Add a package not already in the default package set
-
-This file will continue to work whether you use one or both options.
-Instructions for each option are explained below.
-
-### Overriding/Patching a package
-
-Purpose:
-- Change a package's dependency to a newer/older release than the
-    default package set's release
-- Use your own modified version of some dependency that may
-    include new API, changed API, removed API by
-    using your custom git repo of the library rather than
-    the package set's repo
-
-Syntax:
-Replace the overrides' "{=}" (an empty record) with the following idea
-The "//" or "⫽" means "merge these two records and
-  when they have the same value, use the one on the right:"
--------------------------------
-let override =
-  { packageName =
-      upstream.packageName // { updateEntity1 = "new value", updateEntity2 = "new value" }
-  , packageName =
-      upstream.packageName // { version = "v4.0.0" }
-  , packageName =
-      upstream.packageName // { repo = "https://www.example.com/path/to/new/repo.git" }
-  }
--------------------------------
-
-Example:
--------------------------------
-let overrides =
-  { halogen =
-      upstream.halogen // { version = "master" }
-  , halogen-vdom =
-      upstream.halogen-vdom // { version = "v4.0.0" }
-  }
--------------------------------
-
-### Additions
-
-Purpose:
-- Add packages that aren't already included in the default package set
-
-Syntax:
-Replace the additions' "{=}" (an empty record) with the following idea:
--------------------------------
-let additions =
-  { "package-name" =
-       mkPackage
-         [ "dependency1"
-         , "dependency2"
-         ]
-         "https://example.com/path/to/git/repo.git"
-         "tag ('v4.0.0') or branch ('master')"
-  , "package-name" =
-       mkPackage
-         [ "dependency1"
-         , "dependency2"
-         ]
-         "https://example.com/path/to/git/repo.git"
-         "tag ('v4.0.0') or branch ('master')"
-  , etc.
-  }
--------------------------------
-
-Example:
--------------------------------
-let additions =
-  { benchotron =
-      mkPackage
-        [ "arrays"
-        , "exists"
-        , "profunctor"
-        , "strings"
-        , "quickcheck"
-        , "lcg"
-        , "transformers"
-        , "foldable-traversable"
-        , "exceptions"
-        , "node-fs"
-        , "node-buffer"
-        , "node-readline"
-        , "datetime"
-        , "now"
-        ]
-        "https://github.com/hdgarrood/purescript-benchotron.git"
-        "v7.0.0"
-  }
--------------------------------
--}
-
-let mkPackage =
-      https://raw.githubusercontent.com/purescript/package-sets/psc-0.13.0-20190614/src/mkPackage.dhall sha256:0b197efa1d397ace6eb46b243ff2d73a3da5638d8d0ac8473e8e4a8fc528cf57
-
 let upstream =
-      https://raw.githubusercontent.com/purescript/package-sets/psc-0.13.0-20190614/src/packages.dhall sha256:5cbf2418298e7de762401c5719c6eb18eda4c67ba512b3f076b50a793a7fc482
+      https://github.com/purescript/package-sets/releases/download/psc-0.13.8-20210118/packages.dhall sha256:a59c5c93a68d5d066f3815a89f398bcf00e130a51cb185b2da29b20e2d8ae115
 
-let overrides = {=}
+let overrides =
+      { argonaut-generic = upstream.argonaut-generic ⫽ { version = "v5.0.0" }
+      , argonaut = upstream.argonaut ⫽ { version = "v6.0.0" }
+      , argonaut-codecs = upstream.argonaut-codecs ⫽ { version = "v6.0.2" }
+      , argonaut-traversals =
+          upstream.argonaut-traversals ⫽ { version = "v6.0.0" }
+      }
 
-let additions = {=}
+let additions =
+      { package-name =
+        { dependencies =
+          [ "enums", "foldable-traversable", "maybe", "newtype", "prelude" ]
+        , repo = "git://github.com/purescript/purescript-generics-rep.git"
+        , version = "v6.1.1"
+        }
+      }
 
-in  upstream // overrides // additions
+in  upstream ⫽ overrides ⫽ additions

--- a/spago.dhall
+++ b/spago.dhall
@@ -2,18 +2,17 @@
 Welcome to a Spago project!
 You can edit this file as you like.
 -}
-{ name =
-    "argonaut-aeson-generic"
+{ name = "argonaut-aeson-generic"
 , dependencies =
-    [ "argonaut"
-    , "argonaut-codecs"
-    , "argonaut-generic"
-    , "console"
-    , "effect"
-    , "foreign-object"
-    , "psci-support"
-    , "test-unit"
-    ]
-, packages =
-    ./packages.dhall
+  [ "argonaut"
+  , "argonaut-codecs"
+  , "argonaut-generic"
+  , "console"
+  , "effect"
+  , "foreign-object"
+  , "psci-support"
+  , "test-unit"
+  ]
+, packages = ./packages.dhall
+, sources = [ "src/**/*.purs", "test/**/*.purs" ]
 }


### PR DESCRIPTION
I couldn't build the project with Spago v0.19.  This updated Spago config appears to fix that.

Github Actions modified from https://github.com/purescript-contrib/purescript-argonaut-generic/blob/main/.github/workflows/ci.yml

Appears to work: https://github.com/peterbecich/purescript-argonaut-aeson-generic/actions/runs/562956539